### PR TITLE
v0.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,33 @@
-#Installation
+**Installation**
 
-pip install django_manage_reset_migrations
+*pip install django-manage-reset-migrations*
 
-#Usage
+
+
+**Release 0.1**
+
+**Usage**
+
 Add django_manage_reset_migrations to INSTALLED_APPS
 
-./manage reset_migrations
+*./manage reset_migrations*
 
-It will delete all the applied migrations from the disk and the db.
-Useful when migration files are too many and it slows down the computer.
-Reset migrations using this utility and run makemigration then fake all of them.
+It will delete all the applied migrations from the disk and the db. Useful when migration files are too many and it slows down the computer. Reset migrations using this utility and run makemigration then fake all of them.
+
+**Release 0.2**
+
+**Usage**
+
+Add django_manage_reset_migrations to INSTALLED_APPS
+
+*./manage reset_migrations*
+
+This will delete migrations for all apps from db and disk
+
+./manage reset_migrations --apps app1 app2 app3 ...*
+
+This will delete migration for app1, app2, app3 only.
+
+
+
+*As always pull requests are welcome :)*

--- a/django_manage_reset_migrations/management/commands/reset_migrations.py
+++ b/django_manage_reset_migrations/management/commands/reset_migrations.py
@@ -9,9 +9,13 @@ logger = logging.getLogger(__name__)
 
 
 def delete_migration_file(file_name):
-    logger.debug("Deleting file %s.py" % file_name)
+    message = "Deleting file %s.py" % file_name
+    logger.debug(message)
+    print message
     os.remove("%s.py" % file_name)
-    logger.debug("Deleting file %s.pyc" % file_name)
+    message = "Deleting file %s.pyc" % file_name
+    print message
+    logger.debug(message)
     os.remove("%s.pyc" % file_name)
 
 def get_migration_files(app_label, migration_file_name):
@@ -22,12 +26,21 @@ def get_migration_files(app_label, migration_file_name):
 
 class Command(BaseCommand):
     help = "Deletes all migrations and deletes all migrations from django_migrations table"
-    
+
+    def add_arguments(self, parser):
+        parser.add_argument('--apps', nargs='+')
+
     def handle(self, *args, **options):
         from django.db import connection
         connection = connection
-        migrations_applied = recorder.MigrationRecorder(connection).Migration.objects.all()
+        if options.get('apps', None):
+            migrations_applied = recorder.MigrationRecorder(connection).\
+                    Migration.objects.filter(app__in = options['apps'])
+        else:
+            migrations_applied = recorder.MigrationRecorder(connection).Migration.objects.all()
         for i in migrations_applied:
             delete_migration_file(get_migration_files(i.app, i.name))
-        logger.debug("Deleting migration records from db")
+        message = "Deleting migration records from db"
+        print message
+        logger.debug(message)
         migrations_applied.delete()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-manage-reset-migrations',
-    version='0.1',
+    version='0.2',
     packages=find_packages(),
     include_package_data=True,
     license='',


### PR DESCRIPTION
**Release 0.2**

**Usage**

Add django_manage_reset_migrations to INSTALLED_APPS

_./manage reset_migrations_

This will delete migrations for all apps from db and disk

./manage reset_migrations --apps app1 app2 app3 ...*

This will delete migration for app1, app2, app3 only.
